### PR TITLE
Schema.JSON() function, change schema functions' case

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,10 +142,15 @@ defineTable("users", {
   id: Schema.Number,
   email: Schema.String,
   email_confirmed: Schema.Boolean,
-  profile: Schema.JSON,
+  profile: Schema.JSON(
+    Schema.Object({
+      avatar_url: Schema.String,
+      weblink: Schema.nullable(Schema.String)
+    })
+  ),
   created_at: Schema.default(Schema.Date),
   updated_at: Schema.nullable(Schema.Date),
-  roles: Schema.array(Schema.enum(["admin", "user"]))
+  roles: Schema.Array(Schema.Enum(["admin", "user"]))
 })
 ```
 

--- a/test/schema.test.ts
+++ b/test/schema.test.ts
@@ -7,10 +7,15 @@ test("can define a schema", t => {
       id: Schema.Number,
       email: Schema.String,
       email_confirmed: Schema.Boolean,
-      profile: Schema.JSON,
+      profile: Schema.JSON(
+        Schema.Object({
+          avatar_url: Schema.String,
+          weblink: Schema.nullable(Schema.String)
+        })
+      ),
       created_at: Schema.default(Schema.Date),
       updated_at: Schema.nullable(Schema.Date),
-      roles: Schema.array(Schema.enum(["admin", "user"]))
+      roles: Schema.Array(Schema.Enum(["admin", "user"]))
     })
   )
 })


### PR DESCRIPTION
### Features

#### `Schema.JSON` => `Schema.JSON({ ... })`

Allow defining the structure of JSON column contents.

#### Improved naming scheme for `Schema.*`

Functions defining types, like `Schema.Array()`, are now upper-cased, similar to schema primitives (`Schema.String`, ...).
Functions that add information to a type only, like `Schema.nullable()`, remain lower-cased.